### PR TITLE
메인페이지 url, view 를 팬션 리스트 보이는 url,view, 검색 바 보이는 url,view 로 나눠주기 .

### DIFF
--- a/app/location/crawler.py
+++ b/app/location/crawler.py
@@ -33,7 +33,7 @@ def room_crawler(soup,room_num,url,pension,count_sec_after_popup,count_sec_after
     # 접속.
 
 
-    chromedriver_dir = '/Users/jeonsangmin/project/chromedriver'
+    chromedriver_dir = '/home/nasanmaro/Desktop/projects/yapen/test/selenium_crawling_test/chromedriver'
 
     driver = webdriver.Chrome(chromedriver_dir)
     driver.get(url)
@@ -404,7 +404,7 @@ def location_crawler():
 
     left_menu = soup.select('div.locLayer')
     # 풀빌라, MD추천 제외 14지역중 7지역 만남김.
-    selected_left_menu = left_menu[2:3]
+    selected_left_menu = left_menu[2:4]
 
     for selected_location in selected_left_menu:
         # 지역 이름 먼저 뽑음
@@ -443,8 +443,6 @@ def location_crawler():
                    ypidx=sub_locations_info_list[3][i],  # ypidx,
                    discount_rate=sub_locations_info_list[4][i]   # discount_rate,
                )
-        for location in Location.objects.all():
-            location.pensions_length = len(Pension.objects.filter(location=location))
 
     for location in Location.objects.all():
         sub_location = SubLocation.objects.filter(location=location)

--- a/app/location/serializer/location.py
+++ b/app/location/serializer/location.py
@@ -8,17 +8,15 @@ __all__ = (
     'LocationSerializer',
 )
 
-
+# 검색창에서 쓰이는 Locaiton, SubLocation 의 name, location_no, pension수 보이기 위한 serailzier
 class SubLocationSerializer(serializers.ModelSerializer):
-    pensions = PensionListSerializer(many=True, read_only=True)
-
     class Meta:
         model = SubLocation
         fields =(
             'name',
+            'pensions_length',
             'sub_location_no',
-            'pensions',
-            'pensions_length'
+
         )
 
 
@@ -28,7 +26,8 @@ class LocationSerializer(serializers.ModelSerializer):
         model = Location
         fields =(
             'name',
-            'sublocations',
             'pensions_length',
+            'sublocations',
+
         )
 

--- a/app/location/urls.py
+++ b/app/location/urls.py
@@ -1,14 +1,17 @@
 from django.urls import path
 
-from .views import PensionLocationsList, PensionDetail, PensionSubLocationList
+from .views import PensionLocationNamesList, PensionDetail, PensionSubLocationList, PensionMainList
 
 urlpatterns = [
     path('',
-         PensionLocationsList.as_view(),
-         name='PensionList'),
+         PensionMainList.as_view(),
+         name='PensionMainList'),
+    path('location-name/',
+         PensionLocationNamesList.as_view(),
+         name='PensionLocationsList'),
     path('<str:sub_location_no>/',
          PensionSubLocationList.as_view(),
-         name='PensionLocationList'),
+         name='PensionSubLocationList'),
     path('<str:sub_location_no>/<int:pk>/',
          PensionDetail.as_view(),
          name='PensionList'),

--- a/app/location/views.py
+++ b/app/location/views.py
@@ -10,7 +10,8 @@ from .serializer.pension import PensionDetailSerializer, PensionListSerializer
 from .models import Pension, Location, SubLocation
 
 
-class PensionLocationsList(APIView):
+# 검색창에서 쓰이는 Locaiton, SubLocation 의 name, location_no, pension수 보이기 위한 serailzie
+class PensionLocationNamesList(APIView):
 
     def get(self,request,format=None):
         locations = Location.objects.all()
@@ -22,17 +23,31 @@ class PensionLocationsList(APIView):
         return Response(serializer.data, status=status.HTTP_200_OK)
 
 
+# Main 페이지에서 모든 location에 속한 pension들을 보여주는 viwe
+class PensionMainList(APIView):
+
+    def get(self,request,format=None):
+        pensions = Pension.objects.all()
+        serializer = PensionListSerializer(pensions, many=True)
+
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+# sub_location에 속한 pension들을 보여주는 view
 class PensionSubLocationList(APIView):
 
-    def get_object(self, sub_location_no):
-        try:
-            return  SubLocation.objects.get(sub_location_no=sub_location_no)
-        except SubLocation.DoesNotExist:
-            raise Http404
+    # def get_object(self, sub_location_no):
+    #     try:
+    #         sub_location = SubLocation.objects.get(sub_location_no=sub_location_no)
+    #         return  Pension.objects.filter(sub_location=sub_location.pk)
+    #     except SubLocation.DoesNotExist:
+    #         raise Http404
 
     def get(self,request,sub_location_no,format=None):
-        sublocation = self.get_object(sub_location_no=sub_location_no)
-        serializer = SubLocationSerializer(sublocation)
+        sub_location = SubLocation.objects.get(sub_location_no=sub_location_no)
+        pensions = Pension.objects.filter(sub_location=sub_location.pk)
+        serializer = PensionListSerializer(pensions, many=True)
+
         return Response(serializer.data, status=status.HTTP_200_OK)
 
 


### PR DESCRIPTION
PensionLocationList  클래스 view를 분리해서 PensionLocationNameList, PensionMainList로 나눔.
URL의 경우는 location/location-name/을 location,sublocation의 name필드를 보여주는 view의 주소로 쓰고
	     location/을 IOS, FORNTENDㄲ가 공유해서 쓰는 팬션들만 나오는 view의 url로 쓰기로함.

Sublocation 페이지의 경우도 팬션object의 필드들만 출력하기로함.